### PR TITLE
Update version to 1.3.1 and enhance plugin functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## ⚙️ Changelog
 
+### 1.3.1 - 2025-09-30
+
+- **Security**: Fixed SQL preparation to use proper parameterized queries.
+- **Security**: Implemented request locking mechanism to prevent concurrent executions and race conditions.
+- **Enhancement**: Added REST API parameter sanitization with `rest_sanitize_boolean`.
+- **Enhancement**: Implemented batch processing for large networks (default batch size: 50 sites).
+- **Enhancement**: Added comprehensive error logging for debugging and monitoring.
+- **Enhancement**: Added return type hints to all functions for better code quality.
+- **Enhancement**: Properly registered activation and deactivation hooks with cleanup functionality.
+- **Enhancement**: Created `uninstall.php` for complete data cleanup when plugin is deleted.
+- **Filter**: Added new `all_sites_cron_batch_size` filter to control batch processing size.
+- **Documentation**: Comprehensive filter documentation added to README with practical examples.
+- **Breaking**: Removed `all_sites_cron_sites_transient` filter (sites are no longer cached, processed in batches instead).
+- **Default**: Changed default `all_sites_cron_number_of_sites` from 200 to 1000.
+
 ### 1.3.0 - 2025-09-30
 
 - Rename plugin from `DSS Cron` (slug: `dss-cron`) to `All Sites Cron` (slug: `all-sites-cron`).

--- a/README.md
+++ b/README.md
@@ -89,37 +89,116 @@ jobs:
 
 ### Filters
 
-Adjust maximum sites processed per request (default: 200):
+The plugin provides several filters to customize its behavior:
+
+#### `all_sites_cron_rate_limit_seconds`
+
+Control the cooldown period between cron runs to prevent overlapping executions.
+
+- **Type**: `int`
+- **Default**: `60` (seconds)
+- **Legacy**: `dss_cron_rate_limit_seconds` (still supported)
 
 ```php
-add_filter( 'all_sites_cron_number_of_sites', function( $sites_per_request ) {
-  return 200; // adjust as needed
+add_filter( 'all_sites_cron_rate_limit_seconds', function( $seconds ) {
+    return 120; // 2 minutes between runs
 });
 ```
 
-Adjust transient expiration time (default: 1 hour):
+#### `all_sites_cron_number_of_sites`
+
+Set the maximum number of sites to process in total per request.
+
+- **Type**: `int`
+- **Default**: `1000`
+- **Legacy**: `dss_cron_number_of_sites` (still supported)
 
 ```php
-add_filter( 'all_sites_cron_sites_transient', function( $expiration ) {
-  return 30 * MINUTE_IN_SECONDS; // change site list cache to 30 minutes
+add_filter( 'all_sites_cron_number_of_sites', function( $max_sites ) {
+    return 500; // Process up to 500 sites
 });
 ```
 
-Rate limit (cooldown) between runs (default: 60 seconds):
+#### `all_sites_cron_batch_size`
+
+Control how many sites are processed in each batch. Smaller batches use less memory.
+
+- **Type**: `int`
+- **Default**: `50`
+- **New in**: v1.3.0
 
 ```php
-add_filter( 'all_sites_cron_rate_limit_seconds', function() {
-  return 120; // 2 minutes
+add_filter( 'all_sites_cron_batch_size', function( $batch_size ) {
+    return 25; // Process 25 sites per batch
 });
 ```
 
-Request timeout per site (default: 0.01):
+#### `all_sites_cron_request_timeout`
+
+Set the timeout for wp-cron HTTP requests to each site. Uses "fire and forget" (non-blocking) requests.
+
+- **Type**: `float`
+- **Default**: `0.01` (10 milliseconds)
+- **Legacy**: `dss_cron_request_timeout` (still supported)
 
 ```php
-add_filter( 'all_sites_cron_request_timeout', function() { return 0.05; });
+add_filter( 'all_sites_cron_request_timeout', function( $timeout ) {
+    return 0.05; // 50 milliseconds
+});
 ```
 
-Legacy note: The older `dss_cron_*` filters still work but will be removed in a future major version; update to the `all_sites_cron_*` forms.
+#### `https_local_ssl_verify`
+
+WordPress core filter to control SSL verification for local requests.
+
+- **Type**: `bool`
+- **Default**: `false` (in plugin context)
+- **Core Filter**: This is a WordPress core filter
+
+```php
+add_filter( 'https_local_ssl_verify', function( $verify ) {
+    return true; // Enable SSL verification
+});
+```
+
+### Filter Usage Examples
+
+**Large Network Configuration** (1000+ sites):
+
+```php
+// Process more sites in smaller batches
+add_filter( 'all_sites_cron_number_of_sites', fn() => 2000 );
+add_filter( 'all_sites_cron_batch_size', fn() => 25 );
+add_filter( 'all_sites_cron_rate_limit_seconds', fn() => 180 ); // 3 minutes
+```
+
+**Small Network Configuration** (< 100 sites):
+
+```php
+// Faster processing with larger batches
+add_filter( 'all_sites_cron_batch_size', fn() => 100 );
+add_filter( 'all_sites_cron_rate_limit_seconds', fn() => 30 ); // 30 seconds
+```
+
+**Development/Testing Configuration**:
+
+```php
+// More aggressive settings for testing
+add_filter( 'all_sites_cron_rate_limit_seconds', fn() => 10 ); // 10 seconds
+add_filter( 'all_sites_cron_batch_size', fn() => 5 );
+add_filter( 'all_sites_cron_request_timeout', fn() => 0.1 );
+```
+
+### Legacy Filters
+
+The following legacy filters from the "DSS Cron" plugin are still supported but deprecated:
+
+- `dss_cron_rate_limit_seconds` → Use `all_sites_cron_rate_limit_seconds`
+- `dss_cron_number_of_sites` → Use `all_sites_cron_number_of_sites`
+- `dss_cron_request_timeout` → Use `all_sites_cron_request_timeout`
+- `dss_cron_sites_transient` → No longer used (removed in v1.3.0)
+
+**Migration**: Update your code to use the new `all_sites_cron_*` filter names. Legacy filters will be removed in a future major version.
 
 ### Interpreting Rate Limiting
 

--- a/all-sites-cron.php
+++ b/all-sites-cron.php
@@ -10,7 +10,7 @@
  * Plugin Name: All Sites Cron
  * Plugin URI: https://github.com/soderlind/all-sites-cron
  * Description: Run wp-cron on all public sites in a multisite network via REST API.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+
@@ -48,6 +48,10 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\all_sites_cron_register_rest' );
 // Run one-time upgrade migration for cleaning legacy transients.
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\all_sites_cron_maybe_migrate_legacy_transients', 5 );
 
+// Register activation and deactivation hooks.
+register_activation_hook( ALL_SITES_CRON_FILE, __NAMESPACE__ . '\\all_sites_cron_activation' );
+register_deactivation_hook( ALL_SITES_CRON_FILE, __NAMESPACE__ . '\\all_sites_cron_deactivation' );
+
 /**
  * Register REST API route: /wp-json/all-sites-cron/v1/run
  */
@@ -58,9 +62,11 @@ function all_sites_cron_register_rest(): void {
 		'permission_callback' => '__return_true', // Public like original endpoint.
 		'args'                => [
 			'ga' => [
-				'description' => 'GitHub Actions plain text output mode',
-				'type'        => 'boolean',
-				'required'    => false,
+				'description'       => 'GitHub Actions plain text output mode',
+				'type'              => 'boolean',
+				'required'          => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'default'           => false,
 			],
 		],
 	] );
@@ -70,7 +76,14 @@ function all_sites_cron_register_rest(): void {
 		'methods'             => 'GET',
 		'callback'            => __NAMESPACE__ . '\\all_sites_cron_rest_run',
 		'permission_callback' => '__return_true',
-		'args'                => [ 'ga' => [ 'type' => 'boolean', 'required' => false ] ],
+		'args'                => [
+			'ga' => [
+				'type'              => 'boolean',
+				'required'          => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'default'           => false,
+			],
+		],
 	] );
 }
 
@@ -80,10 +93,26 @@ function all_sites_cron_register_rest(): void {
  * @param \WP_REST_Request $request Request instance.
  * @return \WP_REST_Response|\WP_Error
  */
-function all_sites_cron_rest_run( \WP_REST_Request $request ) {
+function all_sites_cron_rest_run( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 	if ( ! is_multisite() ) {
 		return new \WP_Error( 'all_sites_cron_not_multisite', __( 'This plugin requires WordPress Multisite', 'all-sites-cron' ), [ 'status' => 400 ] );
 	}
+
+	// Request locking: prevent concurrent executions.
+	$lock_key = 'all_sites_cron_lock';
+	if ( false !== get_site_transient( $lock_key ) ) {
+		$message       = __( 'Another cron process is currently running. Please try again later.', 'all-sites-cron' );
+		$ga_mode_check = (bool) $request->get_param( 'ga' );
+		if ( $ga_mode_check ) {
+			$txt      = "::warning::{$message}\n";
+			$response = new \WP_REST_Response( $txt, 409 );
+			$response->header( 'Content-Type', 'text/plain; charset=utf-8' );
+			return $response;
+		}
+		return new \WP_Error( 'all_sites_cron_locked', $message, [ 'status' => 409 ] );
+	}
+	// Set lock for 4 minutes maximum.
+	set_site_transient( $lock_key, time(), MINUTE_IN_SECONDS * 4 );
 
 	// Rate limiting: deny if last run within cooldown window.
 	$cooldown      = (int) apply_filters( 'all_sites_cron_rate_limit_seconds', apply_filters( 'dss_cron_rate_limit_seconds', 60 ) ); // Support legacy filter.
@@ -122,6 +151,13 @@ function all_sites_cron_rest_run( \WP_REST_Request $request ) {
 	$result = all_sites_run_cron_on_all_sites();
 	// Store last successful (attempted) run timestamp regardless of success to enforce cooldown.
 	set_site_transient( 'all_sites_cron_last_run_ts', $now_gmt, $cooldown > 0 ? $cooldown : 60 );
+	// Release the lock.
+	delete_site_transient( 'all_sites_cron_lock' );
+
+	// Log errors if any.
+	if ( empty( $result[ 'success' ] ) && ! empty( $result[ 'message' ] ) ) {
+		error_log( sprintf( '[All Sites Cron] Execution failed: %s', $result[ 'message' ] ) );
+	}
 
 	if ( $ga_mode ) {
 		$txt      = empty( $result[ 'success' ] )
@@ -144,6 +180,7 @@ function all_sites_cron_rest_run( \WP_REST_Request $request ) {
 
 /**
  * Run wp-cron on all public sites in the multisite network.
+ * Uses batch processing for large networks to prevent memory issues.
  * 
  * @return array
  */
@@ -152,47 +189,77 @@ function all_sites_run_cron_on_all_sites(): array {
 		return create_error_response( __( 'This plugin requires WordPress Multisite', 'all-sites-cron' ) );
 	}
 
-	$sites = get_site_transient( 'all_sites_cron_sites' );
-	if ( false === $sites ) {
+	$errors        = [];
+	$total_count   = 0;
+	$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
+	$timeout       = apply_filters( 'all_sites_cron_request_timeout', apply_filters( 'dss_cron_request_timeout', 0.01 ) ); // ultra-short like core spawn_cron(); legacy fallback.
+	$batch_size    = (int) apply_filters( 'all_sites_cron_batch_size', 50 );
+	$max_sites     = (int) apply_filters( 'all_sites_cron_number_of_sites', apply_filters( 'dss_cron_number_of_sites', 1000 ) ); // Legacy filter fallback.
+	$offset        = 0;
+
+	// Process sites in batches to prevent memory issues.
+	do {
 		$sites = get_sites( [
 			'public'   => 1,
 			'archived' => 0,
 			'deleted'  => 0,
 			'spam'     => 0,
-			'number'   => apply_filters( 'all_sites_cron_number_of_sites', apply_filters( 'dss_cron_number_of_sites', 200 ) ), // Legacy filter fallback.
+			'number'   => $batch_size,
+			'offset'   => $offset,
 		] );
-		set_site_transient( 'all_sites_cron_sites', $sites, apply_filters( 'all_sites_cron_sites_transient', apply_filters( 'dss_cron_sites_transient', HOUR_IN_SECONDS ) ) );
-	}
 
-	if ( empty( $sites ) ) {
+		if ( empty( $sites ) ) {
+			break;
+		}
+
+		foreach ( $sites as $site ) {
+			$url      = $site->__get( 'siteurl' );
+			$cron_url = $url . '/wp-cron.php?doing_wp_cron=' . $doing_wp_cron;
+			$response = wp_remote_post( $cron_url, [
+				'timeout'    => $timeout,
+				'blocking'   => false, // fire and forget
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ),
+				'user-agent' => 'All Sites Cron; ' . home_url( '/' ),
+			] );
+			if ( is_wp_error( $response ) ) {
+				$error_msg = sprintf( __( 'Error for %s: %s', 'all-sites-cron' ), $url, $response->get_error_message() );
+				$errors[]  = $error_msg;
+				// Log individual site errors.
+				error_log( sprintf( '[All Sites Cron] %s', $error_msg ) );
+			}
+			$total_count++;
+		}
+
+		$offset += $batch_size;
+
+		// Stop if we've reached the maximum number of sites.
+		if ( $total_count >= $max_sites ) {
+			break;
+		}
+	} while ( count( $sites ) === $batch_size );
+
+	if ( 0 === $total_count ) {
 		return create_error_response( __( 'No public sites found in the network', 'all-sites-cron' ) );
 	}
 
-	$errors        = [];
-	$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
-	$timeout       = apply_filters( 'all_sites_cron_request_timeout', apply_filters( 'dss_cron_request_timeout', 0.01 ) ); // ultra-short like core spawn_cron(); legacy fallback.
-	foreach ( (array) $sites as $site ) {
-		$url      = $site->__get( 'siteurl' );
-		$cron_url = $url . '/wp-cron.php?doing_wp_cron=' . $doing_wp_cron;
-		$response = wp_remote_post( $cron_url, [
-			'timeout'    => $timeout,
-			'blocking'   => false, // fire and forget
-			'sslverify'  => apply_filters( 'https_local_ssl_verify', false ),
-			'user-agent' => 'All Sites Cron; ' . home_url( '/' ),
-		] );
-		if ( is_wp_error( $response ) ) {
-			$errors[] = sprintf( __( 'Error for %s: %s', 'all-sites-cron' ), $url, $response->get_error_message() );
-		}
-	}
-
 	if ( ! empty( $errors ) ) {
-		return create_error_response( implode( "\n", $errors ) );
+		// Return partial success with error details.
+		return [
+			'success' => false,
+			'message' => sprintf(
+				__( 'Completed with %d error(s): %s', 'all-sites-cron' ),
+				count( $errors ),
+				implode( '; ', array_slice( $errors, 0, 3 ) ) . ( count( $errors ) > 3 ? '...' : '' )
+			),
+			'count'   => $total_count,
+			'errors'  => count( $errors ),
+		];
 	}
 
 	return [
 		'success' => true,
 		'message' => '',
-		'count'   => count( (array) $sites ),
+		'count'   => $total_count,
 	];
 }
 
@@ -209,9 +276,31 @@ function create_error_response( $error_message ): array {
 	];
 }
 
-// Activation/deactivation placeholders.
-function all_sites_cron_activation(): void {}
-function all_sites_cron_deactivation(): void {}
+/**
+ * Activation hook: Run on plugin activation.
+ */
+function all_sites_cron_activation(): void {
+	if ( ! is_multisite() ) {
+		return;
+	}
+	// Clear any existing locks and rate limit transients on activation.
+	delete_site_transient( 'all_sites_cron_lock' );
+	delete_site_transient( 'all_sites_cron_last_run_ts' );
+	delete_site_transient( 'all_sites_cron_sites' );
+}
+
+/**
+ * Deactivation hook: Run on plugin deactivation.
+ */
+function all_sites_cron_deactivation(): void {
+	if ( ! is_multisite() ) {
+		return;
+	}
+	// Clear transients on deactivation.
+	delete_site_transient( 'all_sites_cron_lock' );
+	delete_site_transient( 'all_sites_cron_last_run_ts' );
+	delete_site_transient( 'all_sites_cron_sites' );
+}
 
 /**
  * One-time migration: remove legacy dss_cron_* transients after rename.
@@ -230,14 +319,16 @@ function all_sites_cron_maybe_migrate_legacy_transients(): void {
 	global $wpdb;
 
 	// Look for both site_transient and regular transient naming just in case.
-	$like_patterns = [
-		$wpdb->esc_like( '_site_transient_dss_cron_' ) . '%',
-		$wpdb->esc_like( '_transient_dss_cron_' ) . '%',
-	];
+	$site_transient_pattern = $wpdb->esc_like( '_site_transient_dss_cron_' ) . '%';
+	$transient_pattern      = $wpdb->esc_like( '_transient_dss_cron_' ) . '%';
 
-	$placeholders = implode( ' OR option_name LIKE ', array_fill( 0, count( $like_patterns ), '%s' ) );
-	$query        = "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE $placeholders";
-	$rows         = $wpdb->get_col( $wpdb->prepare( $query, $like_patterns ) );
+	// Use proper prepared statement with explicit placeholders.
+	$query = $wpdb->prepare(
+		"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+		$site_transient_pattern,
+		$transient_pattern
+	);
+	$rows  = $wpdb->get_col( $query );
 	if ( ! empty( $rows ) ) {
 		foreach ( $rows as $option_name ) {
 			delete_option( $option_name );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -110,6 +110,17 @@ add_filter( 'all_sites_cron_request_timeout', function() { return 0.05; });
 Legacy filters `dss_cron_*` still work; prefer the new `all_sites_cron_*` names.
 
 == Changelog ==
+
+= 1.3.1 =
+* Fix SQL preparation security issue
+* Add proper REST API parameter sanitization
+* Implement request locking to prevent concurrent executions
+* Add comprehensive error logging
+* Implement batch processing for large networks (default: 50 sites per batch)
+* Add return type hints for better code quality
+* Properly register activation and deactivation hooks
+* Add uninstall.php for complete cleanup on plugin deletion
+* Update filter documentation in README
 
 = 1.3.0 =
 * Rename plugin to All Sites Cron (formerly DSS Cron)

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Uninstall script for All Sites Cron
+ *
+ * Removes all plugin data from the database when the plugin is deleted.
+ *
+ * @package     All_Sites_Cron
+ * @author      Per Soderlind
+ * @copyright   2024 Per Soderlind
+ * @license     GPL-2.0+
+ */
+
+// If uninstall not called from WordPress, exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+/**
+ * Clean up all plugin transients and options.
+ * This runs when the plugin is deleted (not just deactivated).
+ */
+function all_sites_cron_uninstall_cleanup() {
+	if ( ! is_multisite() ) {
+		return;
+	}
+
+	// Remove all site transients created by the plugin.
+	delete_site_transient( 'all_sites_cron_lock' );
+	delete_site_transient( 'all_sites_cron_last_run_ts' );
+	delete_site_transient( 'all_sites_cron_sites' );
+
+	// Remove migration flag.
+	delete_site_option( 'all_sites_cron_migrated_legacy_transients' );
+
+	// Clean up any legacy transients that might still exist.
+	global $wpdb;
+
+	// Prepare patterns for legacy transients.
+	$patterns = [
+		$wpdb->esc_like( '_site_transient_dss_cron_' ) . '%',
+		$wpdb->esc_like( '_transient_dss_cron_' ) . '%',
+		$wpdb->esc_like( '_site_transient_all_sites_cron_' ) . '%',
+		$wpdb->esc_like( '_transient_all_sites_cron_' ) . '%',
+		$wpdb->esc_like( '_site_transient_timeout_dss_cron_' ) . '%',
+		$wpdb->esc_like( '_transient_timeout_dss_cron_' ) . '%',
+		$wpdb->esc_like( '_site_transient_timeout_all_sites_cron_' ) . '%',
+		$wpdb->esc_like( '_transient_timeout_all_sites_cron_' ) . '%',
+	];
+
+	// Remove all matching options in batches.
+	foreach ( $patterns as $pattern ) {
+		$query   = $wpdb->prepare(
+			"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
+			$pattern
+		);
+		$options = $wpdb->get_col( $query );
+
+		if ( ! empty( $options ) ) {
+			foreach ( $options as $option_name ) {
+				delete_option( $option_name );
+			}
+		}
+	}
+}
+
+// Execute cleanup.
+all_sites_cron_uninstall_cleanup();


### PR DESCRIPTION

This pull request introduces version 1.3.1 of the "All Sites Cron" plugin, focusing on significant security improvements, enhanced reliability for large multisite networks, and better developer experience. The update addresses SQL security, adds request locking to prevent concurrent executions, implements batch processing for scalability, improves error logging, and ensures complete cleanup on plugin deletion. It also updates documentation and filter usage for clarity.

**Security and Reliability Improvements**
- Fixed SQL preparation by using properly parameterized queries to prevent SQL injection vulnerabilities.
- Implemented a request locking mechanism to prevent concurrent executions and race conditions during REST API calls.
- Added REST API parameter sanitization using `rest_sanitize_boolean` for safer input handling. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R68-R69) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L73-R86)

**Scalability and Performance**
- Introduced batch processing for large networks, processing sites in configurable batches (default: 50), with a new `all_sites_cron_batch_size` filter for control. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L155-R215) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R201)
- Changed the default maximum number of sites processed per request from 200 to 1000, and removed the caching of site lists in transients for real-time processing. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L155-R215) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R17)

**Error Handling and Logging**
- Added comprehensive error logging for both global and per-site failures, aiding debugging and monitoring. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R154-R160) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L184-R262)

**Plugin Lifecycle and Cleanup**
- Properly registered activation and deactivation hooks to clear transients and locks, and added an `uninstall.php` script to ensure complete data cleanup when the plugin is deleted. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R51-R54) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L212-R303) [[3]](diffhunk://#diff-445f7da6877bb1dda2e959aa7e2bfe91657e7738aca6c2e4337238f612e7865bR1-R67)

**Documentation and Developer Experience**
- Updated README and changelogs with detailed filter documentation, practical usage examples, and migration notes for legacy filters. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R201) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R17) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R114-R124)

**References:** [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L233-R331) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L83-R116) [[3]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R68-R69) [[4]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L73-R86) [[5]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L155-R215) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R201) [[7]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R17) [[8]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R154-R160) [[9]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L184-R262) [[10]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R51-R54) [[11]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L212-R303) [[12]](diffhunk://#diff-445f7da6877bb1dda2e959aa7e2bfe91657e7738aca6c2e4337238f612e7865bR1-R67) [[13]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R114-R124)