### PR TITLE
Implement deferred mode for background processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## ⚙️ Changelog
 
+### 1.4.0 - 2025-10-01
+
+- **Feature**: Added [deferred mode](DEFERRED-MODE.md) (`?defer=1`) for immediate response with background processing.
+- **Enhancement**: Supports FastCGI (`fastcgi_finish_request()`) for Nginx + PHP-FPM, Apache + mod_fcgid.
+- **Enhancement**: Fallback method for Apache mod_php and other configurations.
+- **Enhancement**: Returns HTTP 202 (Accepted) in deferred mode to indicate async processing.
+- **Performance**: Ideal for large networks (100+ sites) to avoid REST API timeouts.
+- **Compatibility**: Full support for modern hosting environments with PHP-FPM.
+- **Documentation**: Comprehensive deferred mode documentation with webserver compatibility details.
+- **Use Case**: Optimized for GitHub Actions and CI/CD pipelines.
+
 ### 1.3.2 - 2025-09-30
 
 - **Documentation**: Fixed readme.txt formatting to comply with WordPress.org standards.

--- a/DEFERRED-MODE.md
+++ b/DEFERRED-MODE.md
@@ -1,0 +1,328 @@
+# Deferred Mode Implementation
+
+## Overview
+
+Deferred mode allows the REST API endpoint to respond immediately (HTTP 202 Accepted) while processing cron jobs in the background. This prevents timeout issues on large networks and improves integration with external systems.
+
+## Usage
+
+Add the `defer=1` parameter to any REST API call:
+
+```bash
+# JSON mode with defer
+curl https://example.com/wp-json/all-sites-cron/v1/run?defer=1
+
+# GitHub Actions mode with defer
+curl https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1
+```
+
+## How It Works
+
+### 1. **Request Flow**
+
+```
+Client Request → REST Handler → Immediate Response (HTTP 202)
+                                      ↓
+                              Background Processing
+                                      ↓
+                              Cron Jobs Execute
+                                      ↓
+                              Log Results
+```
+
+### 2. **Connection Closure Methods**
+
+The plugin uses different methods based on webserver configuration:
+
+#### FastCGI Method (Preferred)
+```php
+if ( function_exists( 'fastcgi_finish_request' ) ) {
+    // Send response
+    echo wp_json_encode( $response->get_data() );
+    
+    // Close connection
+    fastcgi_finish_request();
+    
+    // Continue processing in background
+    all_sites_run_cron_on_all_sites();
+}
+```
+
+**Supported Environments:**
+- Nginx + PHP-FPM ✅
+- Apache + mod_fcgid ✅
+- Litespeed ✅
+
+#### Fallback Method
+```php
+// Flush output buffers
+ob_start();
+echo wp_json_encode( $response->get_data() );
+header('Connection: close');
+header('Content-Length: ' . ob_get_length());
+ob_end_flush();
+flush();
+
+// Continue processing
+all_sites_run_cron_on_all_sites();
+```
+
+**Supported Environments:**
+- Apache + mod_php ⚠️ (works but less reliable)
+- Most shared hosting ⚠️ (depends on configuration)
+
+## Webserver Compatibility
+
+### ✅ Full Support
+
+| Environment | Method | Notes |
+|-------------|--------|-------|
+| Nginx + PHP-FPM | FastCGI | Best performance, cleanest connection closure |
+| Apache + mod_fcgid | FastCGI | Excellent performance |
+| Litespeed | FastCGI | Full support with Litespeed API |
+
+### ⚠️ Partial Support
+
+| Environment | Method | Notes |
+|-------------|--------|-------|
+| Apache + mod_php | Fallback | Works but connection may not close immediately |
+| Shared Hosting | Fallback | Depends on hosting provider's PHP configuration |
+
+### ❌ Not Recommended
+
+| Environment | Issue |
+|-------------|-------|
+| CGI mode | Cannot close connection early |
+| Hosting with aggressive timeouts | May kill long-running processes |
+
+## Testing Your Environment
+
+### 1. Check for FastCGI Support
+
+```bash
+php -r "echo function_exists('fastcgi_finish_request') ? 'FastCGI: YES' : 'FastCGI: NO';"
+```
+
+### 2. Test Deferred Mode
+
+```bash
+# Time the request (should return immediately)
+time curl -X GET "https://example.com/wp-json/all-sites-cron/v1/run?defer=1"
+
+# Expected: < 1 second response time
+# Actual processing continues in background
+```
+
+### 3. Check Background Processing
+
+Monitor your server logs for completion message:
+
+```bash
+tail -f /path/to/php-error.log | grep "All Sites Cron"
+
+# Expected output:
+# [All Sites Cron] Deferred execution completed: 150 sites processed
+```
+
+## Response Examples
+
+### JSON Mode (defer=1)
+
+```json
+{
+  "success": true,
+  "status": "queued",
+  "message": "Cron job queued for background processing",
+  "timestamp": "2025-10-01 12:00:00",
+  "mode": "deferred"
+}
+```
+
+**HTTP Status:** 202 Accepted
+
+### GitHub Actions Mode (ga=1&defer=1)
+
+```
+::notice::Cron job queued for background processing
+```
+
+**HTTP Status:** 202 Accepted
+
+### Synchronous Mode (no defer parameter)
+
+```json
+{
+  "success": true,
+  "count": 150,
+  "message": "",
+  "timestamp": "2025-10-01 12:00:05",
+  "endpoint": "rest"
+}
+```
+
+**HTTP Status:** 200 OK
+
+## Use Cases
+
+### ✅ When to Use Deferred Mode
+
+1. **Large Networks** (100+ sites)
+   - Prevents REST API timeouts
+   - Allows processing to complete without client waiting
+
+2. **GitHub Actions / CI/CD**
+   - Workflow completes quickly
+   - No timeout errors
+   - Can run more frequently
+
+3. **External Monitoring Services**
+   - Services that expect quick responses
+   - Pingdom, UptimeRobot, cron-job.org, etc.
+
+4. **Load Balancers**
+   - Prevents timeout at load balancer level
+   - Better health check responses
+
+### ❌ When NOT to Use Deferred Mode
+
+1. **Small Networks** (< 50 sites)
+   - Synchronous mode is fast enough
+   - No benefit from deferred processing
+
+2. **Debugging / Testing**
+   - Synchronous mode provides immediate feedback
+   - Easier to see errors and results
+
+3. **Sequential Dependencies**
+   - If you need to wait for completion before next action
+   - Synchronous mode ensures completion
+
+## GitHub Actions Configuration
+
+### Recommended Setup
+
+```yaml
+name: All Sites Cron Job
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # Every 5 minutes
+
+env:
+  CRON_ENDPOINT: 'https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1'
+
+jobs:
+  trigger_cron:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2  # Can be reduced with defer mode
+    steps:
+      - name: Trigger Cron
+        run: |
+          curl -X GET ${{ env.CRON_ENDPOINT }} \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 5 \
+            --silent \
+            --show-error \
+            --fail
+```
+
+### Why Use Defer Mode in GitHub Actions?
+
+- ✅ Prevents workflow timeout errors
+- ✅ Faster workflow completion
+- ✅ More reliable execution
+- ✅ Can reduce `timeout-minutes` setting
+- ✅ Lower GitHub Actions billing (faster = cheaper)
+
+## Performance Comparison
+
+| Mode | Network Size | Response Time | Total Time | Best For |
+|------|-------------|---------------|------------|----------|
+| Synchronous | 50 sites | 5 seconds | 5 seconds | Small networks |
+| Synchronous | 200 sites | 20 seconds | 20 seconds | Medium networks |
+| Synchronous | 500 sites | 50 seconds | 50 seconds | Risk of timeout |
+| **Deferred** | 50 sites | < 1 second | 5 seconds* | External triggers |
+| **Deferred** | 200 sites | < 1 second | 20 seconds* | GitHub Actions |
+| **Deferred** | 500 sites | < 1 second | 50 seconds* | Large networks |
+
+\* Total time happens in background; client doesn't wait
+
+## Troubleshooting
+
+### Issue: "Connection not closing"
+
+**Symptom:** Request takes full processing time despite defer=1
+
+**Solutions:**
+1. Check if `fastcgi_finish_request()` exists:
+   ```bash
+   php -r "var_dump(function_exists('fastcgi_finish_request'));"
+   ```
+
+2. Verify PHP-FPM is being used:
+   ```bash
+   php -i | grep "Server API"
+   # Should show: FPM/FastCGI
+   ```
+
+3. Check for output buffering conflicts in wp-config.php
+
+### Issue: "Process killed during background execution"
+
+**Symptom:** Cron doesn't complete on all sites
+
+**Solutions:**
+1. Increase PHP timeout in php.ini:
+   ```ini
+   max_execution_time = 300
+   ```
+
+2. Check for hosting-level process restrictions
+
+3. Consider reducing `all_sites_cron_batch_size` filter
+
+### Issue: "No log output"
+
+**Symptom:** Can't see completion message in logs
+
+**Solutions:**
+1. Enable PHP error logging in php.ini:
+   ```ini
+   log_errors = On
+   error_log = /path/to/php-error.log
+   ```
+
+2. Check WordPress debug log if WP_DEBUG_LOG is enabled
+
+3. Verify file permissions on log file
+
+## Security Considerations
+
+1. **No Additional Risk:** Deferred mode uses same permissions as synchronous mode
+2. **Rate Limiting:** Still applies (60-second default cooldown)
+3. **Request Locking:** Prevents concurrent executions
+4. **Log Monitoring:** Background execution is logged for auditing
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+- [ ] Queue system with database storage
+- [ ] Status endpoint to check background job progress
+- [ ] Webhook callbacks when processing completes
+- [ ] Priority queue for specific sites
+- [ ] Progress tracking API
+
+## Support
+
+If you encounter issues with deferred mode:
+
+1. Check this documentation first
+2. Test your environment compatibility
+3. Review server logs for errors
+4. Open an issue on GitHub with:
+   - PHP version
+   - Webserver type and version
+   - Hosting environment
+   - Error logs

--- a/README.md
+++ b/README.md
@@ -41,10 +41,29 @@ GitHub Actions plain text (add `?ga=1`):
 https://example.com/wp-json/all-sites-cron/v1/run?ga=1
 ```
 
+[Deferred mode](DEFERRED-MODE.md) (add `?defer=1` - responds immediately, processes in background):
+
+```
+https://example.com/wp-json/all-sites-cron/v1/run?defer=1
+```
+
+Combine parameters (GitHub Actions + Deferred):
+
+```
+https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1
+```
+
 Adding `?ga=1` outputs results in GitHub Actions compatible format:
 
 - Success: `::notice::Running wp-cron on X sites`
 - Error: `::error::Error message`
+
+<details>
+
+  <summary>Example GitHub Action success notice</summary>
+
+  <img src="assets/ga-output.png" alt="GitHub Action - Success notice" style="with: 60%">
+</details>
 
 ## ⏰ Trigger Options
 
@@ -58,6 +77,8 @@ Adding `?ga=1` outputs results in GitHub Actions compatible format:
 
 3. GitHub Actions (every 5 minutes. 5 minutes is the [shortest interval in GitHub Actions](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)):
 
+2. GitHub Actions (every 5 minutes):
+
 ```yaml
 name: All Sites Cron Job
 on:
@@ -65,7 +86,7 @@ on:
     - cron: '*/5 * * * *'
 
 env:
-  CRON_ENDPOINT: 'https://example.com/wp-json/all-sites-cron/v1/run?ga=1'
+  CRON_ENDPOINT: 'https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1'
 
 jobs:
   trigger_cron:
@@ -82,6 +103,8 @@ jobs:
             --show-error \
             --fail
 ```
+
+**Note:** Using `defer=1` is recommended for GitHub Actions to prevent timeout errors on large networks.
 
 ## Customization
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.3.2
+Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,9 +25,17 @@ Usage (JSON):
 GitHub Actions format:
 `https://example.com/wp-json/all-sites-cron/v1/run?ga=1`
 
+Deferred mode (responds immediately, processes in background):
+`https://example.com/wp-json/all-sites-cron/v1/run?defer=1`
+
+Combine parameters:
+`https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1`
+
 Adding `?ga=1` to the URL outputs results in GitHub Actions compatible format:
 - Success: `::notice::Running wp-cron on X sites`
 - Error: `::error::Error message`
+
+Deferred mode (`?defer=1`) returns HTTP 202 immediately and processes in background. Ideal for large networks (100+ sites) and GitHub Actions to prevent timeout errors. Works best with Nginx + PHP-FPM, Apache + mod_fcgid, and most modern hosting.
 
 = Trigger Options =
 
@@ -45,7 +53,7 @@ on:
     - cron: '*/5 * * * *'
 
 env:
-  CRON_ENDPOINT: 'https://example.com/wp-json/all-sites-cron/v1/run?ga=1'
+  CRON_ENDPOINT: 'https://example.com/wp-json/all-sites-cron/v1/run?ga=1&defer=1'
 
 jobs:
   trigger_cron:
@@ -105,6 +113,15 @@ Plugin updates are handled automatically via GitHub. No need to manually downloa
 
 
 == Changelog ==
+
+= 1.4.0 =
+* Add deferred mode with `defer=1` parameter for immediate response and background processing
+* Support for FastCGI (`fastcgi_finish_request()`) on Nginx + PHP-FPM and Apache + mod_fcgid
+* Fallback method for Apache mod_php and other configurations
+* Return HTTP 202 (Accepted) in deferred mode
+* Ideal for large networks (100+ sites) to prevent REST API timeouts
+* Optimized for GitHub Actions and CI/CD pipelines
+* Add comprehensive webserver compatibility documentation
 
 = 1.3.2 =
 * Documentation updates and readme.txt formatting fixes


### PR DESCRIPTION
This pull request introduces a major new feature: "deferred mode" for the All Sites Cron plugin, allowing REST API calls to return immediately (HTTP 202) while cron jobs are processed in the background. This is especially beneficial for large multisite networks and environments like GitHub Actions, reducing timeout risks and improving reliability. The implementation includes webserver-specific connection handling, comprehensive documentation, and updates to usage instructions and examples.

**Key changes:**

**Deferred Mode Feature and Implementation**
- Added support for a `defer=1` parameter to the REST API, enabling immediate HTTP 202 responses while cron jobs are processed asynchronously in the background. The implementation uses FastCGI (`fastcgi_finish_request()`) when available, with a robust fallback for other server configurations. Logging and error handling are included to ensure reliability and transparency. (`all-sites-cron.php`, `DEFERRED-MODE.md`, [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R71-R77) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R93-R98) [[3]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L103-R125) [[4]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L114-R162) [[5]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R178-R250) [[6]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L175-R266) [[7]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R370-R428) [[8]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R13) [[9]](diffhunk://#diff-a1b3834244b75d8180581733af9bca482a008118d572bba458ae24bdaf4b5d55R1-R328)

**Documentation and Usage Updates**
- Added a new `DEFERRED-MODE.md` with detailed documentation on deferred mode, including usage, webserver compatibility, troubleshooting, and best practices. Updated `README.md` and `readme.txt` to explain and recommend deferred mode, especially for GitHub Actions and large networks. (`DEFERRED-MODE.md`, `README.md`, `readme.txt`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R108) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R28-R39)

**Examples and GitHub Actions Integration**
- Updated example API calls and GitHub Actions workflow snippets to use `?defer=1` by default, demonstrating how to combine deferred mode with GitHub Actions output (`?ga=1&defer=1`). Added notes and visuals to highlight the benefits of deferred mode in CI/CD pipelines. (`README.md`, `readme.txt`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R108) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L48-R56)

**Locking and Rate Limiting Improvements**
- Enhanced locking logic to handle stale locks and ensure the lock is always released, even in the event of errors or exceptions. Improved rate limiting by releasing locks before returning on rate limit errors. (`all-sites-cron.php`, [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L103-R125) [[2]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L114-R162) [[3]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6R178-R250)

**Version and Changelog Bump**
- Bumped plugin version to 1.4.0 and updated changelogs to reflect the new feature and enhancements. (`all-sites-cron.php`, `CHANGELOG.md`, `readme.txt`, [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L13-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R13) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)