### PR TITLE
Fix documentation links in readme.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## ⚙️ Changelog
 
+### 1.5.2 - 2025-10-01
+- Fix links in readme.txt, to point to correct documentation files.
+
 ### 1.5.1 - 2025-10-01
 
 - Add links to docs from readme.txt

--- a/all-sites-cron.php
+++ b/all-sites-cron.php
@@ -10,7 +10,7 @@
  * Plugin Name: All Sites Cron
  * Plugin URI: https://github.com/soderlind/all-sites-cron
  * Description: Run wp-cron on all public sites in a multisite network via REST API.
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron,redis
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -44,9 +44,9 @@ Deferred mode (`?defer=1`) returns HTTP 202 immediately and processes in backgro
 - [Plugin Homepage](https://github.com/soderlind/all-sites-cron)
 - [Triggering Options](https://github.com/soderlind/all-sites-cron#-trigger-options)
 - [Filters](https://github.com/soderlind/all-sites-cron#filters)
-- [Deferred Mode](https://github.com/soderlind/all-sites-cron/DEFERRED-MODE.md)
-- [Redis Quick Start](https://github.com/soderlind/all-sites-cron/REDIS-QUICK-START.md)
-- [Redis Queue](https://github.com/soderlind/all-sites-cron/REDIS-QUEUE.md)
+- [Deferred Mode](https://github.com/soderlind/all-sites-cron/blob/main/DEFERRED-MODE.md)
+- [Redis Quick Start](https://github.com/soderlind/all-sites-cron/blob/main/REDIS-QUICK-START.md)
+- [Redis Queue](https://github.com/soderlind/all-sites-cron/blob/main/REDIS-QUEUE.md)
 
 == Installation ==
 
@@ -61,6 +61,9 @@ Plugin updates are handled automatically via GitHub. No need to manually downloa
 
 
 == Changelog ==
+
+= 1.5.2 =
+* Fix links in readme.txt, to point to correct documentation files.
 
 = 1.5.1 =
 * Add links to docs from readme.txt


### PR DESCRIPTION
This pull request updates the plugin to version 1.5.2 and primarily fixes documentation links in the `readme.txt` file to ensure they point to the correct documentation files. It also updates version references throughout the project to reflect the new release.

Documentation improvements:

* Fixed links in `readme.txt` to point to the correct documentation files using the `/blob/main/` path, ensuring users are directed to the right resources.
* Added a changelog entry for version 1.5.2 in both `CHANGELOG.md` and `readme.txt`, describing the link fix. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R67)

Version updates:

* Updated the plugin version to 1.5.2 in `all-sites-cron.php`, `readme.txt` (Stable tag), and changelogs to reflect the new release. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L13-R13) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R67)